### PR TITLE
Migrate to .NET Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ Install-Package FirebaseDatabase.net -pre
 ```
 
 ## Supported frameworks
-* .NET 4.5+
-* Windows 8.x
-* UWP
-* Windows Phone 8.1
-* CoreCLR
+* .NET Standard 1.5
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install-Package FirebaseDatabase.net -pre
 ```
 
 ## Supported frameworks
-* .NET Standard 1.5
+* .NET Standard 1.1
 
 ## Usage
 

--- a/src/Firebase.Tests/Firebase.Tests.csproj
+++ b/src/Firebase.Tests/Firebase.Tests.csproj
@@ -73,12 +73,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Firebase\Firebase.csproj">
-      <Project>{ff9d620c-0241-4ad3-b3ab-200f11cad936}</Project>
-      <Name>Firebase</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Choose>

--- a/src/Firebase.Tests/packages.config
+++ b/src/Firebase.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.6.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
 </packages>

--- a/src/Firebase/FireBase.csproj
+++ b/src/Firebase/FireBase.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{FF9D620C-0241-4AD3-B3AB-200F11CAD936}</ProjectGuid>
@@ -13,8 +13,9 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Firebase/Firebase.nuspec
+++ b/src/Firebase/Firebase.nuspec
@@ -24,8 +24,8 @@
 		<copyright>Step Up Labs, Inc. 2016</copyright>
 		<tags>Firebase Database Realtime</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="8.0.3" />
-      <dependency id="Rx-Main" version="2.2.5" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
+      <dependency id="System.Reactive" version="3.1.1" />
     </dependencies>
 	</metadata>
 </package>

--- a/src/Firebase/Firebase.nuspec
+++ b/src/Firebase/Firebase.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
 		<id>FirebaseDatabase.net</id>
-		<version>2.0.2</version>
+		<version>2.1.0</version>
 		<title>FirebaseDatabase.net</title>
 		<authors>Step Up Labs, Inc.</authors>
 		<owners>Step Up Labs, Inc.</owners>

--- a/src/Firebase/project.json
+++ b/src/Firebase/project.json
@@ -1,10 +1,12 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "Newtonsoft.Json": "8.0.3",
-    "Rx-Main": "2.2.5"
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "NETStandard.Library": "1.6.0",
+    "Newtonsoft.Json": "9.0.1",
+    "System.Reactive": "3.1.1"
   },
   "frameworks": {
-    ".NETPortable,Version=v4.5,Profile=Profile111": {}
+    "netstandard1.5": {}
   }
 }

--- a/src/Firebase/project.json
+++ b/src/Firebase/project.json
@@ -2,11 +2,10 @@
   "supports": {},
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
-    "NETStandard.Library": "1.6.0",
     "Newtonsoft.Json": "9.0.1",
     "System.Reactive": "3.1.1"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netstandard1.1": {}
   }
 }


### PR DESCRIPTION
Hi,


This should do the job to target .NET Standard 1.1. Only the Firebase project has been updated, and the offline capability has left untouched. This should allow them to work side by side without any impact. 