### PR TITLE
Authenticating with service account token

### DIFF
--- a/src/Firebase/FirebaseOptions.cs
+++ b/src/Firebase/FirebaseOptions.cs
@@ -63,5 +63,14 @@
             get;
             set;
         }
+
+        /// <summary>
+        /// Specify if token returned by factory will be used as "auth" url parameter or "access_token". 
+        /// </summary>
+        public bool AsAccessToken
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/Firebase/Query/AuthQuery.cs
+++ b/src/Firebase/Query/AuthQuery.cs
@@ -15,7 +15,7 @@ namespace Firebase.Database.Query
         /// <param name="parent"> The parent.  </param>  
         /// <param name="tokenFactory"> The authentication token factory. </param>
         /// <param name="client"> The owner. </param>
-        public AuthQuery(FirebaseQuery parent, Func<string> tokenFactory, FirebaseClient client) : base(parent, () => "auth", client)
+        public AuthQuery(FirebaseQuery parent, Func<string> tokenFactory, FirebaseClient client) : base(parent, () => client.Options.AsAccessToken ? "access_token" : "auth", client)
         {
             this.tokenFactory = tokenFactory;
         }


### PR DESCRIPTION
added a flag allowing to use access_token url parameter needed for authetincating using service account insted of auth used by default.