### PR TITLE
handle array data

### DIFF
--- a/src/Firebase.Tests/FirebaseCacheTests.cs
+++ b/src/Firebase.Tests/FirebaseCacheTests.cs
@@ -345,5 +345,42 @@
                 ["b"] = "bb",
             }));
         }
+
+
+
+        [TestMethod]
+        public void InitialPushOfEntireArrayToEmptyCache()
+        {
+            // Data that looks like an array will be returned as an array (without keys).
+            // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
+
+            // this should simulate first time connection is made and all data is returned in a batch in a form of a dictionary
+            var cache = new FirebaseCache<Dinosaur>();
+            var dinosaurs = @"[
+  {
+    ""ds"": {
+      ""height"" : 2,
+      ""length"" : 2,
+      ""weight"": 2
+    }
+  },
+  {
+    ""ds"": {
+      ""height"" : 3,
+      ""length"" : 3,
+      ""weight"" : 3
+    }
+  }
+]";
+
+            var entities = cache.PushData("/", dinosaurs).ToList();
+            var expectation = new[]
+            {
+                new FirebaseObject<Dinosaur>("0", new Dinosaur(2, 2, 2)),
+                new FirebaseObject<Dinosaur>("1", new Dinosaur(3, 3, 3))
+            };
+
+            entities.ShouldAllBeEquivalentTo(expectation);
+        }
     }
 }

--- a/src/Firebase/Http/HttpClientExtensions.cs
+++ b/src/Firebase/Http/HttpClientExtensions.cs
@@ -59,7 +59,20 @@ namespace Firebase.Database.Http
         public static IEnumerable<FirebaseObject<object>> GetObjectCollection(this string data, Type elementType)
         {
             var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), elementType);
-            var dictionary = JsonConvert.DeserializeObject(data, dictionaryType) as IDictionary;
+            IDictionary dictionary = null;
+
+            if (data.StartsWith("["))
+            {
+                var listType = typeof(List<>).MakeGenericType(elementType);
+                var list = JsonConvert.DeserializeObject(data, listType) as IList;
+                dictionary = Activator.CreateInstance(dictionaryType) as IDictionary;
+                var index = 0;
+                foreach (var item in list) dictionary.Add(index++.ToString(), item);
+            }
+            else
+            {
+                dictionary = JsonConvert.DeserializeObject(data, dictionaryType) as IDictionary;
+            }
 
             if (dictionary == null)
             {


### PR DESCRIPTION
Data that looks like an array will be returned as an array (without keys) instead of a object.
https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html