### PR TITLE
handle null and boolean filters

### DIFF
--- a/src/Firebase/Query/FilterQuery.cs
+++ b/src/Firebase/Query/FilterQuery.cs
@@ -10,6 +10,7 @@ namespace Firebase.Database.Query
     {
         private readonly Func<string> valueFactory;
         private readonly Func<double> doubleValueFactory;
+        private readonly Func<bool> boolValueFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FilterQuery"/> class.
@@ -38,6 +39,19 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="FilterQuery"/> class.
+        /// </summary>
+        /// <param name="parent"> The parent. </param>
+        /// <param name="filterFactory"> The filter. </param>
+        /// <param name="valueFactory"> The value for filter. </param>
+        /// <param name="client"> The owning client. </param>
+        public FilterQuery(FirebaseQuery parent, Func<string> filterFactory, Func<bool> valueFactory, FirebaseClient client)
+            : base(parent, filterFactory, client)
+        {
+            this.boolValueFactory = valueFactory;
+        }
+
+        /// <summary>
         /// The build url parameter.
         /// </summary>
         /// <param name="child"> The child. </param> 
@@ -46,11 +60,19 @@ namespace Firebase.Database.Query
         {
             if (this.valueFactory != null)
             {
+                if(this.valueFactory() == null)
+                {
+                    return $"null";
+                }
                 return $"\"{this.valueFactory()}\"";
             }
             else if (this.doubleValueFactory != null)
             {
                 return this.doubleValueFactory().ToString(CultureInfo.InvariantCulture);
+            }
+            else if (this.boolValueFactory != null)
+            {
+                return $"{this.boolValueFactory().ToString().ToLower()}";
             }
 
             return string.Empty;

--- a/src/Firebase/Query/QueryExtensions.cs
+++ b/src/Firebase/Query/QueryExtensions.cs
@@ -107,6 +107,27 @@ namespace Firebase.Database.Query
         {
             return child.EqualTo(() => value);
         }
+        
+        /// <summary>
+        /// Instructs firebase to send data equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <param name="value"> Value to start at. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery EqualTo(this ParameterQuery child, bool value)
+        {
+            return child.EqualTo(() => value);
+        }  
+
+        /// <summary>
+        /// Instructs firebase to send data equal to null. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery EqualTo(this ParameterQuery child)
+        {
+            return child.EqualTo(() => null);
+        }        
 
         /// <summary>
         /// Limits the result to first <see cref="count"/> items.

--- a/src/Firebase/Query/QueryFactoryExtensions.cs
+++ b/src/Firebase/Query/QueryFactoryExtensions.cs
@@ -139,6 +139,17 @@ namespace Firebase.Database.Query
         {
             return new FilterQuery(child, () => "equalTo", valueFactory, child.Client);
         }
+		
+        /// <summary>
+        /// Instructs firebase to send data equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <param name="valueFactory"> Value to start at. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery EqualTo(this ParameterQuery child, Func<bool> valueFactory)
+        {
+            return new FilterQuery(child, () => "equalTo", valueFactory, child.Client);
+        }		
 
         /// <summary>
         /// Limits the result to first <see cref="countFactory"/> items.


### PR DESCRIPTION
This will allow null (the key does not exist) and boolean filters.

For example: 
orderBy="xxxxxx"&equalTo=null
or
orderBy="xxxxxx"&equalTo=true

Before, the only choices were double or string which did not work for null or boolean.
