### PR TITLE
Bugfix: converting from JSON should replace, not append.

### DIFF
--- a/src/Firebase.Tests/Entities/HNChanges.cs
+++ b/src/Firebase.Tests/Entities/HNChanges.cs
@@ -1,0 +1,16 @@
+namespace Firebase.Database.Tests.Entities
+{
+    using System.Collections.Generic;
+
+    public class HNChanges
+    {
+        public HNChanges()
+        {
+            this.items = new List<long>();
+            this.profiles = new List<string>();
+        }
+
+        public IList<long> items { get; set; }
+        public IList<string> profiles { get; set; }
+    }
+}

--- a/src/Firebase.Tests/Firebase.Tests.csproj
+++ b/src/Firebase.Tests/Firebase.Tests.csproj
@@ -64,6 +64,7 @@
   <ItemGroup>
     <Compile Include="Entities\Dinosaur.cs" />
     <Compile Include="Entities\Dimensions.cs" />
+    <Compile Include="Entities\HNChanges.cs" />
     <Compile Include="Entities\JurassicWorld.cs" />
     <Compile Include="FirebaseCacheTests.cs" />
     <Compile Include="FirebasePathTests.cs" />

--- a/src/Firebase.Tests/FirebaseCacheTests.cs
+++ b/src/Firebase.Tests/FirebaseCacheTests.cs
@@ -382,5 +382,35 @@
 
             entities.ShouldAllBeEquivalentTo(expectation);
         }
+
+        [TestMethod]
+        public void ExistingKeyShouldReplace()
+        {
+            var cache = new FirebaseCache<HNChanges>();
+            var original = @"
+                {
+                    ""items"": [1, 2, 3],
+                    ""profiles"": [""a"", ""b"", ""c""]
+                }";
+            var incoming = @"
+                {
+                    ""items"": [4, 5, 6],
+                    ""profiles"": [""d"", ""e"", ""f""]
+                }";
+            var expectation = new []
+            {
+                new FirebaseObject<HNChanges>("updates", new HNChanges()
+                    {
+                        items = new List<long>() { 4, 5, 6 },
+                        profiles = new List<string>() { "d", "e", "f" }
+                    }
+                )
+            };
+
+            cache.PushData("updates/", original).ToList();
+            var entities = cache.PushData("updates/", incoming).ToList();
+
+            entities.ShouldAllBeEquivalentTo(expectation);
+        }
     }
 }

--- a/src/Firebase/Streaming/FirebaseCache.cs
+++ b/src/Firebase/Streaming/FirebaseCache.cs
@@ -18,6 +18,10 @@ namespace Firebase.Database.Streaming
     {
         private readonly IDictionary<string, T> dictionary;
         private readonly bool isDictionaryType;
+        private readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings()
+        {
+            ObjectCreationHandling = ObjectCreationHandling.Replace
+        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FirebaseCache{T}"/> class.
@@ -146,7 +150,7 @@ namespace Firebase.Database.Streaming
                 }
                 else
                 {
-                    JsonConvert.PopulateObject(data, obj);
+                    JsonConvert.PopulateObject(data, obj, this.serializerSettings);
                 }
 
                 this.dictionary[pathElements[0]] = this.dictionary[pathElements[0]];


### PR DESCRIPTION
Ran into this issue with Hacker News' streaming updates, all keys kept getting appended instead of replace.

Closes #107
Requested changes from #108 

If/When this gets merged, I'd like to request a new version up on nuget.