### PR TITLE
Only return elementRoot as initial data instead of every item (offline)

### DIFF
--- a/src/Firebase/Offline/RealtimeDatabase.cs
+++ b/src/Firebase/Offline/RealtimeDatabase.cs
@@ -193,13 +193,21 @@
 
             if (this.observable == null)
             {
-                var initialData = this.Database.Count == 0
-                    ? Observable.Return(FirebaseEvent<T>.Empty(FirebaseEventSource.Offline))
-                    : this.Database
+                var initialData = Observable.Empty<FirebaseEvent<T>>();
+                if(this.Database.TryGetValue(this.elementRoot, out OfflineEntry oe))
+                {
+                    initialData = Observable.Return(offlineEntry)
+                        .Where(offlineEntry => !string.IsNullOrEmpty(offlineEntry.Data) && offlineEntry.Data != "null" && !offlineEntry.IsPartial)
+                        .Select(offlineEntry => new FirebaseEvent<T>(offlineEntry.Key, offlineEntry.Deserialize<T>(), FirebaseEventType.InsertOrUpdate, FirebaseEventSource.Offline));
+                }
+                else if(this.Database.Count > 0)
+                {
+                    initialData = this.Database
                         .Where(kvp => !string.IsNullOrEmpty(kvp.Value.Data) && kvp.Value.Data != "null" && !kvp.Value.IsPartial)
                         .Select(kvp => new FirebaseEvent<T>(kvp.Key, kvp.Value.Deserialize<T>(), FirebaseEventType.InsertOrUpdate, FirebaseEventSource.Offline))
                         .ToList()
                         .ToObservable();
+                }
 
                 this.observable = initialData
                     .Merge(this.subject)

--- a/src/Firebase/Offline/RealtimeDatabase.cs
+++ b/src/Firebase/Offline/RealtimeDatabase.cs
@@ -270,14 +270,18 @@
             {
                 case StreamingOptions.LatestOnly:
                     // stream since the latest key
-                    var queryLatest = this.childQuery.OrderByKey().StartAt(() => this.GetLatestKey());
+                    // If elementRoot is provided, create a child query so we can observe that single element instead of the whole collection.
+                    var queryLatest = string.IsNullOrWhiteSpace(this.elementRoot) ?
+                        (IFirebaseQuery)this.childQuery.OrderByKey().StartAt(() => this.GetLatestKey()) :
+                        this.childQuery.Child(this.elementRoot);
                     this.firebaseSubscription = new FirebaseSubscription<T>(observer, queryLatest, this.elementRoot, this.firebaseCache);
                     this.firebaseSubscription.ExceptionThrown += this.StreamingExceptionThrown;
 
                     return new CompositeDisposable(this.firebaseSubscription.Run(), completeDisposable);
                 case StreamingOptions.Everything:
                     // stream everything
-                    var queryAll = this.childQuery;
+                    // If elementRoot is provided, create a child query so we can observe that single element instead of the whole collection.
+                    var queryAll = this.childQuery.Child(this.elementRoot);
                     this.firebaseSubscription = new FirebaseSubscription<T>(observer, queryAll, this.elementRoot, this.firebaseCache);
                     this.firebaseSubscription.ExceptionThrown += this.StreamingExceptionThrown;
 

--- a/src/Firebase/Offline/RealtimeDatabase.cs
+++ b/src/Firebase/Offline/RealtimeDatabase.cs
@@ -196,7 +196,7 @@
                 var initialData = Observable.Empty<FirebaseEvent<T>>();
                 if(this.Database.TryGetValue(this.elementRoot, out OfflineEntry oe))
                 {
-                    initialData = Observable.Return(offlineEntry)
+                    initialData = Observable.Return(oe)
                         .Where(offlineEntry => !string.IsNullOrEmpty(offlineEntry.Data) && offlineEntry.Data != "null" && !offlineEntry.IsPartial)
                         .Select(offlineEntry => new FirebaseEvent<T>(offlineEntry.Key, offlineEntry.Deserialize<T>(), FirebaseEventType.InsertOrUpdate, FirebaseEventSource.Offline));
                 }

--- a/src/Firebase/Offline/RealtimeDatabase.cs
+++ b/src/Firebase/Offline/RealtimeDatabase.cs
@@ -193,7 +193,7 @@
 
             if (this.observable == null)
             {
-                var initialData = Observable.Empty<FirebaseEvent<T>>();
+                var initialData = Observable.Return(FirebaseEvent<T>.Empty(FirebaseEventSource.Offline));
                 if(this.Database.TryGetValue(this.elementRoot, out OfflineEntry oe))
                 {
                     initialData = Observable.Return(oe)
@@ -278,18 +278,14 @@
             {
                 case StreamingOptions.LatestOnly:
                     // stream since the latest key
-                    // If elementRoot is provided, create a child query so we can observe that single element instead of the whole collection.
-                    var queryLatest = string.IsNullOrWhiteSpace(this.elementRoot) ?
-                        (IFirebaseQuery)this.childQuery.OrderByKey().StartAt(() => this.GetLatestKey()) :
-                        this.childQuery.Child(this.elementRoot);
+                    var queryLatest = this.childQuery.OrderByKey().StartAt(() => this.GetLatestKey());
                     this.firebaseSubscription = new FirebaseSubscription<T>(observer, queryLatest, this.elementRoot, this.firebaseCache);
                     this.firebaseSubscription.ExceptionThrown += this.StreamingExceptionThrown;
 
                     return new CompositeDisposable(this.firebaseSubscription.Run(), completeDisposable);
                 case StreamingOptions.Everything:
                     // stream everything
-                    // If elementRoot is provided, create a child query so we can observe that single element instead of the whole collection.
-                    var queryAll = this.childQuery.Child(this.elementRoot);
+                    var queryAll = this.childQuery;
                     this.firebaseSubscription = new FirebaseSubscription<T>(observer, queryAll, this.elementRoot, this.firebaseCache);
                     this.firebaseSubscription.ExceptionThrown += this.StreamingExceptionThrown;
 

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -115,7 +115,9 @@ namespace Firebase.Database.Query
         {
             return Observable.Create<FirebaseEvent<T>>(observer =>
             {
-                var sub = new FirebaseSubscription<T>(observer, this, elementRoot, new FirebaseCache<T>());
+                // If elementRoot is provided, create a child query so we can observe that single element instead of the whole collection.
+                var query = string.IsNullOrWhiteSpace(elementRoot) ? this : new ChildQuery(this, () => elementRoot, this.Client);
+                var sub = new FirebaseSubscription<T>(observer, query, elementRoot, new FirebaseCache<T>());
                 sub.ExceptionThrown += exceptionHandler;
                 return sub.Run();
             });

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -115,9 +115,7 @@ namespace Firebase.Database.Query
         {
             return Observable.Create<FirebaseEvent<T>>(observer =>
             {
-                // If elementRoot is provided, create a child query so we can observe that single element instead of the whole collection.
-                var query = string.IsNullOrWhiteSpace(elementRoot) ? this : new ChildQuery(this, () => elementRoot, this.Client);
-                var sub = new FirebaseSubscription<T>(observer, query, elementRoot, new FirebaseCache<T>());
+                var sub = new FirebaseSubscription<T>(observer, this, elementRoot, new FirebaseCache<T>());
                 sub.ExceptionThrown += exceptionHandler;
                 return sub.Run();
             });

--- a/src/Firebase/Streaming/FirebaseCache.cs
+++ b/src/Firebase/Streaming/FirebaseCache.cs
@@ -158,6 +158,11 @@ namespace Firebase.Database.Streaming
             }
         }
 
+        public bool Contains(string key)
+        {
+            return this.dictionary.Keys.Contains(key);
+        }
+
         private object CreateInstance(Type type)
         {
             if (type == typeof(string))

--- a/src/Firebase/Streaming/FirebaseSubscription.cs
+++ b/src/Firebase/Streaming/FirebaseSubscription.cs
@@ -184,10 +184,14 @@ namespace Firebase.Database.Streaming
                     var path = result["path"].ToString();
                     var data = result["data"].ToString();
 
-                    if (path == "/" && data == string.Empty)
+                    // If an elementRoot parameter is provided, but it's not in the cache, it was already deleted. So we can return an empty object.
+                    if(string.IsNullOrWhiteSpace(this.elementRoot) || !this.cache.Contains(this.elementRoot))
                     {
-                        this.observer.OnNext(FirebaseEvent<T>.Empty(FirebaseEventSource.OnlineStream));
-                        return;
+                        if(path == "/" && data == string.Empty)
+                        {
+                            this.observer.OnNext(FirebaseEvent<T>.Empty(FirebaseEventSource.OnlineStream));
+                            return;
+                        }
                     }
 
                     var eventType = string.IsNullOrWhiteSpace(data) ? FirebaseEventType.Delete : FirebaseEventType.InsertOrUpdate;


### PR DESCRIPTION
Can now observe single elements instead of the whole collection (both online and offline). Verified using the two included sample console applications.