### PR TITLE
HttpClient life-cycle management. 

### DIFF
--- a/src/Firebase/FirebaseClient.cs
+++ b/src/Firebase/FirebaseClient.cs
@@ -29,7 +29,7 @@ namespace Firebase.Database
         public FirebaseClient(string baseUrl, FirebaseOptions options = null)
         {
             this.Options = options ?? new FirebaseOptions();
-            this.HttpClient = Options.HttpClientFactory.GetHttpClient();
+            this.HttpClient = Options.HttpClientFactory.GetHttpClient(null);
 
             this.baseUrl = baseUrl;
 

--- a/src/Firebase/FirebaseClient.cs
+++ b/src/Firebase/FirebaseClient.cs
@@ -28,8 +28,8 @@ namespace Firebase.Database
         /// <param name="offlineDatabaseFactory"> Offline database. </param>  
         public FirebaseClient(string baseUrl, FirebaseOptions options = null)
         {
-            this.HttpClient = new HttpClient();
             this.Options = options ?? new FirebaseOptions();
+            this.HttpClient = Options.HttpClientFactory.GetHttpClient();
 
             this.baseUrl = baseUrl;
 

--- a/src/Firebase/FirebaseClient.cs
+++ b/src/Firebase/FirebaseClient.cs
@@ -16,7 +16,7 @@ namespace Firebase.Database
     /// </summary>
     public class FirebaseClient : IDisposable
     {
-        internal readonly HttpClient HttpClient;
+        internal readonly IHttpClientProxy HttpClient;
         internal readonly FirebaseOptions Options;
 
         private readonly string baseUrl;

--- a/src/Firebase/FirebaseOptions.cs
+++ b/src/Firebase/FirebaseOptions.cs
@@ -17,6 +17,7 @@
             this.SubscriptionStreamReaderFactory = s => new StreamReader(s);
             this.JsonSerializerSettings = new JsonSerializerSettings();
             this.SyncPeriod = TimeSpan.FromSeconds(10);
+            this.HttpClientFactory = new TransientHttpClientFactory();
         }
 
         /// <summary>
@@ -69,6 +70,14 @@
         /// </summary>
         public bool AsAccessToken
         {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Specify HttpClient factory to manage <see cref="System.Net.Http.HttpClient" /> lifecycle.
+        /// </summary>
+        public IHttpClientFactory HttpClientFactory {
             get;
             set;
         }

--- a/src/Firebase/Http/IHttpClientFactory.cs
+++ b/src/Firebase/Http/IHttpClientFactory.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Net.Http;
+
+namespace Firebase
+{
+    public interface IHttpClientFactory
+    {
+        HttpClient GetHttpClient();
+    }
+}

--- a/src/Firebase/Http/IHttpClientFactory.cs
+++ b/src/Firebase/Http/IHttpClientFactory.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Net.Http;
 
 namespace Firebase
 {
     public interface IHttpClientFactory
     {
-        HttpClient GetHttpClient(TimeSpan? timeout);
+        IHttpClientProxy GetHttpClient(TimeSpan? timeout);
     }
 }

--- a/src/Firebase/Http/IHttpClientFactory.cs
+++ b/src/Firebase/Http/IHttpClientFactory.cs
@@ -5,6 +5,6 @@ namespace Firebase
 {
     public interface IHttpClientFactory
     {
-        HttpClient GetHttpClient();
+        HttpClient GetHttpClient(TimeSpan? timeout);
     }
 }

--- a/src/Firebase/Http/IHttpClientProxy.cs
+++ b/src/Firebase/Http/IHttpClientProxy.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Net.Http;
+
+namespace Firebase
+{
+    public interface IHttpClientProxy : IDisposable
+    {
+        HttpClient GetHttpClient();
+    }
+}

--- a/src/Firebase/Http/SimpleHttpClientProxy.cs
+++ b/src/Firebase/Http/SimpleHttpClientProxy.cs
@@ -1,0 +1,24 @@
+﻿using System.Net.Http;
+
+namespace Firebase
+{
+    internal sealed class SimpleHttpClientProxy : IHttpClientProxy
+    {
+        private readonly HttpClient _httpClient;
+
+        public SimpleHttpClientProxy(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public HttpClient GetHttpClient()
+        {
+            return _httpClient;
+        }
+
+        public void Dispose()
+        {
+            _httpClient?.Dispose();
+        }
+    }
+}

--- a/src/Firebase/Http/TransientHttpClientFactory.cs
+++ b/src/Firebase/Http/TransientHttpClientFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Net.Http;
+
+namespace Firebase
+{
+    internal sealed class TransientHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient GetHttpClient()
+        {
+            return new HttpClient();
+        }
+    }
+}

--- a/src/Firebase/Http/TransientHttpClientFactory.cs
+++ b/src/Firebase/Http/TransientHttpClientFactory.cs
@@ -5,9 +5,13 @@ namespace Firebase
 {
     internal sealed class TransientHttpClientFactory : IHttpClientFactory
     {
-        public HttpClient GetHttpClient()
+        public HttpClient GetHttpClient(TimeSpan? timeout)
         {
-            return new HttpClient();
+            var client = new HttpClient();
+            if (timeout != null) {
+                client.Timeout = timeout.Value;
+            }
+            return client;
         }
     }
 }

--- a/src/Firebase/Http/TransientHttpClientFactory.cs
+++ b/src/Firebase/Http/TransientHttpClientFactory.cs
@@ -5,13 +5,14 @@ namespace Firebase
 {
     internal sealed class TransientHttpClientFactory : IHttpClientFactory
     {
-        public HttpClient GetHttpClient(TimeSpan? timeout)
+        public IHttpClientProxy GetHttpClient(TimeSpan? timeout)
         {
             var client = new HttpClient();
             if (timeout != null) {
                 client.Timeout = timeout.Value;
             }
-            return client;
+
+            return new SimpleHttpClientProxy(client);
         }
     }
 }

--- a/src/Firebase/Offline/SetHandler.cs
+++ b/src/Firebase/Offline/SetHandler.cs
@@ -6,15 +6,18 @@
 
     public class SetHandler<T> : ISetHandler<T>
     {
-        public virtual Task SetAsync(ChildQuery query, string key, OfflineEntry entry)
+        public virtual async Task SetAsync(ChildQuery query, string key, OfflineEntry entry)
         {
-            if (entry.SyncOptions == SyncOptions.Put)
+            using (var child = query.Child(key))
             {
-                return query.Child(key).PutAsync(entry.Data);
-            }
-            else
-            {
-                return query.Child(key).PatchAsync(entry.Data);
+                if (entry.SyncOptions == SyncOptions.Put)
+                {
+                    await child.PutAsync(entry.Data);
+                }
+                else
+                {
+                    await child.PatchAsync(entry.Data);
+                }
             }
         }
     }

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -259,7 +259,7 @@ namespace Firebase.Database.Query
         {
             if (this.client == null)
             {
-                this.client = new HttpClient();
+                this.client = Client.Options.HttpClientFactory.GetHttpClient();
             }
 
             if (!timeout.HasValue)

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -22,7 +22,7 @@ namespace Firebase.Database.Query
 
         protected readonly FirebaseQuery Parent;
 
-        private HttpClient client;
+        private IHttpClientProxy client;
 
         /// <summary> 
         /// Initializes a new instance of the <see cref="FirebaseQuery"/> class.
@@ -262,7 +262,7 @@ namespace Firebase.Database.Query
                 this.client = Client.Options.HttpClientFactory.GetHttpClient(timeout ?? DEFAULT_HTTP_CLIENT_TIMEOUT);
             }
 
-            return this.client;
+            return this.client.GetHttpClient();
         }
 
         private async Task<string> SendAsync(HttpClient client, string data, HttpMethod method)

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -259,16 +259,7 @@ namespace Firebase.Database.Query
         {
             if (this.client == null)
             {
-                this.client = Client.Options.HttpClientFactory.GetHttpClient();
-            }
-
-            if (!timeout.HasValue)
-            {
-                this.client.Timeout = DEFAULT_HTTP_CLIENT_TIMEOUT;
-            }
-            else
-            {
-                this.client.Timeout = timeout.Value;
+                this.client = Client.Options.HttpClientFactory.GetHttpClient(timeout ?? DEFAULT_HTTP_CLIENT_TIMEOUT);
             }
 
             return this.client;


### PR DESCRIPTION
Hi guys,
we recently had a problem with the sdk. After some investigation we figured out that the problem was - using too many HttpClients. If you are running on high throughput - the application is choking. We are running our code in Azure Functions on consumption plan, it is limited to 300 http connections. We reached the limit pretty quickly unfortunately. 
There is an anti-pattern  described [here](https://docs.microsoft.com/en-us/azure/architecture/antipatterns/improper-instantiation). 
I left everything as is, just added a possibility to use our own `HttpClient` factory. This way we can create a singleton `HttpClient` in our code and dispose it on `Application End`. I've added a default implementation of `TransientHttpClientFactory` to mimic the existing behavior, so nothing will break for any other consumers. All the test are passing as well. 
Thanks in advance! 