### PR TITLE
Added support for data type LONG (Number in Firebase) in queries

### DIFF
--- a/src/Firebase/Query/FilterQuery.cs
+++ b/src/Firebase/Query/FilterQuery.cs
@@ -10,6 +10,7 @@ namespace Firebase.Database.Query
     {
         private readonly Func<string> valueFactory;
         private readonly Func<double> doubleValueFactory;
+        private readonly Func<long> longValueFactory;
         private readonly Func<bool> boolValueFactory;
 
         /// <summary>
@@ -45,6 +46,19 @@ namespace Firebase.Database.Query
         /// <param name="filterFactory"> The filter. </param>
         /// <param name="valueFactory"> The value for filter. </param>
         /// <param name="client"> The owning client. </param>
+        public FilterQuery(FirebaseQuery parent, Func<string> filterFactory, Func<long> valueFactory, FirebaseClient client)
+            : base(parent, filterFactory, client)
+        {
+            this.longValueFactory = valueFactory;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterQuery"/> class.
+        /// </summary>
+        /// <param name="parent"> The parent. </param>
+        /// <param name="filterFactory"> The filter. </param>
+        /// <param name="valueFactory"> The value for filter. </param>
+        /// <param name="client"> The owning client. </param>
         public FilterQuery(FirebaseQuery parent, Func<string> filterFactory, Func<bool> valueFactory, FirebaseClient client)
             : base(parent, filterFactory, client)
         {
@@ -69,6 +83,10 @@ namespace Firebase.Database.Query
             else if (this.doubleValueFactory != null)
             {
                 return this.doubleValueFactory().ToString(CultureInfo.InvariantCulture);
+            }
+            else if (this.longValueFactory != null)
+            {
+                return this.longValueFactory().ToString();
             }
             else if (this.boolValueFactory != null)
             {

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -260,15 +260,15 @@ namespace Firebase.Database.Query
             if (this.client == null)
             {
                 this.client = new HttpClient();
-            }
 
-            if (!timeout.HasValue)
-            {
-                this.client.Timeout = DEFAULT_HTTP_CLIENT_TIMEOUT;
-            }
-            else
-            {
-                this.client.Timeout = timeout.Value;
+                if (!timeout.HasValue)
+                {
+                    this.client.Timeout = DEFAULT_HTTP_CLIENT_TIMEOUT;
+                }
+                else
+                {
+                    this.client.Timeout = timeout.Value;
+                }
             }
 
             return this.client;

--- a/src/Firebase/Query/QueryExtensions.cs
+++ b/src/Firebase/Query/QueryExtensions.cs
@@ -119,7 +119,40 @@ namespace Firebase.Database.Query
         {
             return child.EqualTo(() => value);
         }
-        
+
+        /// <summary>
+        /// Instructs firebase to send data greater or equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <param name="value"> Value to start at. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery StartAt(this ParameterQuery child, long value)
+        {
+            return child.StartAt(() => value);
+        }
+
+        /// <summary>
+        /// Instructs firebase to send data lower or equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <param name="value"> Value to start at. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery EndAt(this ParameterQuery child, long value)
+        {
+            return child.EndAt(() => value);
+        }
+
+        /// <summary>
+        /// Instructs firebase to send data equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <param name="value"> Value to start at. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery EqualTo(this ParameterQuery child, long value)
+        {
+            return child.EqualTo(() => value);
+        }
+
         /// <summary>
         /// Instructs firebase to send data equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
         /// </summary>

--- a/src/Firebase/Query/QueryFactoryExtensions.cs
+++ b/src/Firebase/Query/QueryFactoryExtensions.cs
@@ -139,7 +139,40 @@ namespace Firebase.Database.Query
         {
             return new FilterQuery(child, () => "equalTo", valueFactory, child.Client);
         }
-		
+
+        /// <summary>
+        /// Instructs firebase to send data greater or equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <param name="valueFactory"> Value to start at. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery StartAt(this ParameterQuery child, Func<long> valueFactory)
+        {
+            return new FilterQuery(child, () => "startAt", valueFactory, child.Client);
+        }
+
+        /// <summary>
+        /// Instructs firebase to send data lower or equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <param name="valueFactory"> Value to start at. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery EndAt(this ParameterQuery child, Func<long> valueFactory)
+        {
+            return new FilterQuery(child, () => "endAt", valueFactory, child.Client);
+        }
+
+        /// <summary>
+        /// Instructs firebase to send data equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// </summary>
+        /// <param name="child"> Current node. </param>
+        /// <param name="valueFactory"> Value to start at. </param>
+        /// <returns> The <see cref="FilterQuery"/>. </returns>
+        public static FilterQuery EqualTo(this ParameterQuery child, Func<long> valueFactory)
+        {
+            return new FilterQuery(child, () => "equalTo", valueFactory, child.Client);
+        }
+
         /// <summary>
         /// Instructs firebase to send data equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>


### PR DESCRIPTION
Hi, I added support for data type long in order to be able to store and query a timestamp that is based on ticks. When using double, which is already supported, then the ticks are converted to some digit format. Only alternative currently would be to use a string. But as Number in Firebase is a signed 64bit integer I think it makes sense to support a long object in the queries directly. So I can now do this:

```C#
var _lastDataSyncTime = DateTime.Now;
var data = await _childData
    .OrderBy("Updated")  
    .StartAt(_lastDataSyncTime.Ticks.ToString())  // <- long directly passed into URL
    .OnceAsync<Data>();
```

I added support for start, end and equalTo, similar to what is supported for double and string already