### PR TITLE
Virtual implementation of FirebaseCache

### DIFF
--- a/src/Firebase/Firebase.csproj
+++ b/src/Firebase/Firebase.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>FirebaseDatabase.net</PackageId>
-    <PackageVersion>4.0.1</PackageVersion>
+    <PackageVersion>4.0.2</PackageVersion>
     <Authors>Step Up Labs, Inc.</Authors>
     <Description>Complex C# library for Firebase Realtime Database built on top of Firebase REST API. Among others it supports following:
 
@@ -15,7 +15,6 @@
 
       Streaming changes (both online and offline) are done using Reactive Extensions.
     </Description>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageIconUrl>https://github.com/step-up-labs/firebase-database-dotnet/raw/master/art/FirebaseLogo.128x128.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/step-up-labs/firebase-database-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/step-up-labs/firebase-database-dotnet/blob/master/LICENSE</PackageLicenseUrl>
@@ -23,6 +22,7 @@
     <IncludeSymbols>True</IncludeSymbols>
     <Copyright>Step Up Labs, Inc. 2017</Copyright>
     <PackageTags>Firebase Database Realtime</PackageTags>
+    <PackOnBuild>true</PackOnBuild>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Firebase/FirebaseObject.cs
+++ b/src/Firebase/FirebaseObject.cs
@@ -6,7 +6,7 @@ namespace Firebase.Database
     /// <typeparam name="T"> Type of the underlying object. </typeparam> 
     public class FirebaseObject<T> 
     {
-        internal FirebaseObject(string key, T obj)
+        public FirebaseObject(string key, T obj)
         {
             this.Key = key;
             this.Object = obj;

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -105,17 +105,37 @@ namespace Firebase.Database.Query
             }
         }
 
+        ///// <summary>
+        ///// Starts observing this query watching for changes real time sent by the server.
+        ///// </summary>
+        ///// <typeparam name="T"> Type of elements. </typeparam>
+        ///// <param name="elementRoot"> Optional custom root element of received json items. </param>
+        ///// <returns> Observable stream of <see cref="FirebaseEvent{T}"/>. </returns>
+        //public IObservable<FirebaseEvent<T>> AsObservable<T>(EventHandler<ContinueExceptionEventArgs<FirebaseException>> exceptionHandler = null, string elementRoot = "")
+        //{
+        //    return Observable.Create<FirebaseEvent<T>>(observer =>
+        //    {
+        //        var sub = new FirebaseSubscription<T>(observer, this, elementRoot, new FirebaseCache<T>());
+        //        sub.ExceptionThrown += exceptionHandler;
+        //        return sub.Run();
+        //    });
+        //}
+
         /// <summary>
         /// Starts observing this query watching for changes real time sent by the server.
         /// </summary>
         /// <typeparam name="T"> Type of elements. </typeparam>
         /// <param name="elementRoot"> Optional custom root element of received json items. </param>
         /// <returns> Observable stream of <see cref="FirebaseEvent{T}"/>. </returns>
-        public IObservable<FirebaseEvent<T>> AsObservable<T>(EventHandler<ContinueExceptionEventArgs<FirebaseException>> exceptionHandler = null, string elementRoot = "")
+        public IObservable<FirebaseEvent<T>> AsObservable<T>(EventHandler<ContinueExceptionEventArgs<FirebaseException>> exceptionHandler = null, string elementRoot = "", FirebaseCache<T> cache=null)
         {
             return Observable.Create<FirebaseEvent<T>>(observer =>
             {
-                var sub = new FirebaseSubscription<T>(observer, this, elementRoot, new FirebaseCache<T>());
+                if (cache==null)
+                {
+                    cache = new FirebaseCache<T>();
+                }
+                var sub = new FirebaseSubscription<T>(observer, this, elementRoot, cache);
                 sub.ExceptionThrown += exceptionHandler;
                 return sub.Run();
             });

--- a/src/Firebase/Query/IFirebaseQuery.cs
+++ b/src/Firebase/Query/IFirebaseQuery.cs
@@ -32,7 +32,7 @@
         /// </summary>
         /// <typeparam name="T"> Type of the items. </typeparam>
         /// <returns> Cold observable of <see cref="FirebaseEvent{T}"/>. </returns>
-        IObservable<FirebaseEvent<T>> AsObservable<T>(EventHandler<ContinueExceptionEventArgs<FirebaseException>> exceptionHandler, string elementRoot = "");
+        IObservable<FirebaseEvent<T>> AsObservable<T>(EventHandler<ContinueExceptionEventArgs<FirebaseException>> exceptionHandler, string elementRoot = "", FirebaseCache<T> cache = null);
 
         /// <summary>
         /// Builds the actual url of this query.

--- a/src/Firebase/Streaming/FirebaseCache.cs
+++ b/src/Firebase/Streaming/FirebaseCache.cs
@@ -47,7 +47,7 @@ namespace Firebase.Database.Streaming
         /// <param name="path"> The path of incoming data, separated by slash. </param>  
         /// <param name="data"> The data in json format as returned by firebase. </param>  
         /// <returns> Collection of top-level entities which were affected by the push. </returns>
-        public IEnumerable<FirebaseObject<T>> PushData(string path, string data, bool removeEmptyEntries = true)
+        public virtual IEnumerable<FirebaseObject<T>> PushData(string path, string data, bool removeEmptyEntries = true)
         {
             object obj = this.dictionary;
             Action<object> primitiveObjSetter = null;
@@ -162,7 +162,7 @@ namespace Firebase.Database.Streaming
             }
         }
 
-        public bool Contains(string key)
+        public virtual bool Contains(string key)
         {
             return this.dictionary.Keys.Contains(key);
         }
@@ -186,7 +186,7 @@ namespace Firebase.Database.Streaming
             return this.GetEnumerator();
         }
 
-        public IEnumerator<FirebaseObject<T>> GetEnumerator()
+        public virtual IEnumerator<FirebaseObject<T>> GetEnumerator()
         {
             return this.dictionary.Select(p => new FirebaseObject<T>(p.Key, p.Value)).GetEnumerator();
         }

--- a/src/Firebase/Streaming/FirebaseSingleObjectCache.cs
+++ b/src/Firebase/Streaming/FirebaseSingleObjectCache.cs
@@ -1,0 +1,87 @@
+﻿namespace Firebase.Database.Streaming
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Newtonsoft.Json;
+
+    public class FirebaseSingleObjectCache<T> : FirebaseCache<T>
+    {
+        private T RootObject;
+
+        private bool hasRootData;
+
+        public override IEnumerable<FirebaseObject<T>> PushData(string path, string data, bool removeEmptyEntries = true)
+        {
+            if (path.Equals("/"))
+            {
+                if (hasRootData)
+                {
+                    JsonConvert.PopulateObject(data, RootObject);
+                }
+                else
+                {
+                    RootObject = JsonConvert.DeserializeObject<T>(data);
+                    hasRootData = true;
+                }
+                yield return new FirebaseObject<T>("/", RootObject);
+            }
+            else
+            {
+                object obj = RootObject;
+                if (hasRootData)
+                {
+                    var objType = obj.GetType();
+
+                    var pathElements = path.Split(new[] { "/" }, removeEmptyEntries ? StringSplitOptions.RemoveEmptyEntries : StringSplitOptions.None);
+
+                    //var setPropertyValue = true;
+
+                    foreach (var element in pathElements)
+                    {
+                        if (obj is IDictionary dict)
+                        {
+                            var dictType = dict.GetType();
+                            var itemType = dictType.BaseType.GenericTypeArguments[1];
+                            objType = itemType;
+                            if (dict.Contains(element))
+                            {
+                                obj = dict[element];
+                            }
+                            else
+                            {
+                                obj = Activator.CreateInstance(itemType);
+                                dict.Add(element, obj);
+                            }
+                        }
+                        else
+                        {
+                            var prp = objType.GetProperties().FirstOrDefault(d => d.Name.Equals(element, StringComparison.InvariantCultureIgnoreCase));
+                            if (prp != null)
+                            {
+                                obj = prp.GetValue(obj);
+                                objType = obj.GetType();
+                            }
+                        }
+
+                    }
+                    if (!string.IsNullOrEmpty(data))
+                    {
+                        if (objType.IsPrimitive)
+                        {
+                            obj = Convert.ChangeType(data, objType);
+                        }
+                        else
+                        {
+                            JsonConvert.PopulateObject(data, obj);
+                        }
+                        yield return new FirebaseObject<T>("/", RootObject);
+                    }
+
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Example implementation of custom cache.

userObserver = client
                .Child("users")
                .Child(id)
                .AsObservable((sender, e) =>
                {
                    e.IgnoreAndContinue = true;
                }, "", new FirebaseSingleObjectCache<Models.User>())
                .Subscribe((user) =>
                  {
                      if (user.Object != null)
                      {
                          onUserUpdate?.Invoke(user.Object);
                      }

                  });
