### PR TITLE
add new item to list of data and let the user parse their own generat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ var firebase = new FirebaseClient("https://dinosaur-facts.firebaseio.com/");
 var dino = await firebase
   .Child("dinosaurs")
   .PostAsync(new Dinosaur());
+
+
+// add new item to list of data and let the user parse their own generated key 
+string generatedKey = Guid.NewGuid().ToString();
+var dino = await firebase
+  .Child("dinosaurs")
+  .PostAsync(new Dinosaur(), generatedKey);
   
 // note that there is another overload for the PostAsync method which delegates the new key generation to the firebase server
   
@@ -100,6 +107,7 @@ await firebase
   .Child("dinosaurs")
   .Child("t-rex")
   .PutAsync(new Dinosaur());
+  
 
 // delete given child node
 await firebase

--- a/src/Firebase.Tests/FirebaseQueryTest.cs
+++ b/src/Firebase.Tests/FirebaseQueryTest.cs
@@ -1,0 +1,54 @@
+﻿using Firebase.Database.Query;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Firebase.Database.Tests
+{
+    [TestClass]
+    public class FirebaseQueryTest
+    {
+        public const string BasePath = "https://fir-testproject-d6ced.firebaseio.com/";
+        [TestMethod]
+        public void TestPostAsyncParameterWithAllNull()
+        {
+            FirebaseClient firebaseClient = new FirebaseClient(BasePath, new FirebaseOptions());
+            FirebaseObject<string> result = firebaseClient.Child("dinosaurs").PostAsync("", "").Result;
+
+            Assert.AreEqual(null, result.Key);
+        }
+        [TestMethod]
+        public void TestPostAsyncParameterWithDataNull()
+        {
+            string generatedKey = Guid.NewGuid().ToString();
+            FirebaseClient firebaseClient = new FirebaseClient(BasePath, new FirebaseOptions());
+            FirebaseObject<string> result = firebaseClient.Child("dinosaurs").PostAsync("", generatedKey).Result;
+
+            Assert.AreEqual(null, result.Key);
+        }
+        [TestMethod]
+        public void TestPostAsyncParameterWithGeneratedKeyNull()
+        {
+            FirebaseClient firebaseClient = new FirebaseClient(BasePath, new FirebaseOptions());
+            string data = JsonConvert.SerializeObject(new Entities.Dinosaur(2, 2, 2));
+            FirebaseObject<string> result = firebaseClient.Child("dinosaurs").PostAsync(data, "").Result;
+
+            Assert.AreEqual(null, result.Key);
+        }
+        [TestMethod]
+        public void TestPostAsyncParameterWithAllParameterPassed()
+        {
+            FirebaseClient firebaseClient = new FirebaseClient(BasePath, new FirebaseOptions());
+            string generatedKey = Guid.NewGuid().ToString();
+            string data = JsonConvert.SerializeObject(new Entities.Dinosaur(2, 2, 2));
+            FirebaseObject<string> result = firebaseClient.Child("dinosaurs").PostAsync(data, generatedKey).Result;
+
+            Assert.IsNotNull(result.Key, "the object returned is null");
+        }
+
+    }
+}

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -164,6 +164,29 @@ namespace Firebase.Database.Query
                 return new FirebaseObject<string>(result.Name, data);
             }
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="definedKey"></param>
+        /// <param name=""></param>
+        /// <returns></returns>
+        public async Task<FirebaseObject<string>> PostAsync(string data, string definedKey)
+        {
+            //ensure the key parsed is not an empty string and must have a value
+            if (!string.IsNullOrEmpty(definedKey) && !string.IsNullOrEmpty(data)){
+                // definedKey here is parsed by the user, this is the key the user want to use while creating the node on firebase
+                await new ChildQuery(this, () => definedKey, this.Client).PutAsync(data).ConfigureAwait(false);
+                return new FirebaseObject<string>(definedKey, data);
+            }
+            else
+            {
+                //otherwise return null 
+                return new FirebaseObject<string>(null, null);
+            }
+            
+
+        }
 
         /// <summary>
         /// Patches data at given location instead of overwriting them.


### PR DESCRIPTION
In the original FirebaseQuery - PostAsync method User cannot parse their own generated key. Which was my issue while trying to use the library, because in my own case, the generated  key of each node is saved in the database and this key is needed while creating a new node. 

So to solve this, i implemented a function overload, still PostAsync allowing user to parse their own generated key, and still push the desired children inside the parent node.

i have written a test for each cases for the function overload i wrote