### PR TITLE
PullAsync fix

### DIFF
--- a/src/Firebase/Extensions/ObservableExtensions.cs
+++ b/src/Firebase/Extensions/ObservableExtensions.cs
@@ -11,6 +11,7 @@
         /// <param name="source">The source observable.</param>
         /// <param name="dueTime">How long to wait between attempts.</param>
         /// <param name="retryOnError">A predicate determining for which exceptions to retry. Defaults to all</param>
+        /// <param name="retryCount">The number of attempts of running the source observable before failing.</param>
         /// <returns>
         /// A cold observable which retries (re-subscribes to) the source observable on error up to the 
         /// specified number of times or until it successfully terminates.
@@ -18,21 +19,31 @@
         public static IObservable<T> RetryAfterDelay<T, TException>(
             this IObservable<T> source,
             TimeSpan dueTime,
-            Func<TException, bool> retryOnError)
+            Func<TException, bool> retryOnError,
+            int? retryCount = null)
             where TException: Exception
         {
             int attempt = 0;
 
-            return Observable.Defer(() =>
+            var pipeline = Observable.Defer(() =>
             {
                 return ((++attempt == 1) ? source : source.DelaySubscription(dueTime))
                     .Select(item => new Tuple<bool, T, Exception>(true, item, null))
                     .Catch<Tuple<bool, T, Exception>, TException>(e => retryOnError(e)
                         ? Observable.Throw<Tuple<bool, T, Exception>>(e)
                         : Observable.Return(new Tuple<bool, T, Exception>(false, default(T), e)));
-            })
-            .Retry()
-            .SelectMany(t => t.Item1
+            });
+
+            if (retryCount.HasValue)
+            {
+                pipeline = pipeline.Retry(retryCount.Value);
+            }
+            else
+            {
+                pipeline = pipeline.Retry();
+            }
+
+            return pipeline.SelectMany(t => t.Item1
                 ? Observable.Return(t.Item2)
                 : Observable.Throw<T>(t.Item3));
         }


### PR DESCRIPTION
**Current behavior**
In RealtimeDatabase.PullAsync, if the first call to OnceAsync fails, all following retries return the result of that same failed task, instead of re-executing the OnceAsync task.

**New behavior**
Re-executes the failed task upon Retry by wrapping OnceAsync in a Defer call. I also added an optional parameter to PullAsync and RetryAfterDelay that specifies how many times it should retry; otherwise, it just hangs until successful.