### PR TITLE
xml doc fixes and minor optimizations

### DIFF
--- a/src/Firebase/FirebaseClient.cs
+++ b/src/Firebase/FirebaseClient.cs
@@ -25,7 +25,7 @@ namespace Firebase.Database
         /// Initializes a new instance of the <see cref="FirebaseClient"/> class.
         /// </summary>
         /// <param name="baseUrl"> The base url. </param>
-        /// <param name="offlineDatabaseFactory"> Offline database. </param>  
+        /// <param name="options"> The Firebase options. </param>  
         public FirebaseClient(string baseUrl, FirebaseOptions options = null)
         {
             this.Options = options ?? new FirebaseOptions();

--- a/src/Firebase/FirebaseKeyGenerator.cs
+++ b/src/Firebase/FirebaseKeyGenerator.cs
@@ -7,7 +7,7 @@ namespace Firebase.Database
     /// Offline key generator which mimics the official Firebase generators. 
     /// Credit: https://github.com/bubbafat/FirebaseSharp/blob/master/src/FirebaseSharp.Portable/FireBasePushIdGenerator.cs
     /// </summary>
-    public class FirebaseKeyGenerator 
+    public static class FirebaseKeyGenerator 
     {
         // Modeled after base64 web-safe chars, but ordered by ASCII.
         private const string PushCharsString = "-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";

--- a/src/Firebase/FirebaseObject.cs
+++ b/src/Firebase/FirebaseObject.cs
@@ -1,7 +1,7 @@
 namespace Firebase.Database
 {
     /// <summary>
-    /// Holds the object of type <typeparam name="T" /> along with its key. 
+    /// Holds the object of type <typeparamref name="T" /> along with its key. 
     /// </summary>
     /// <typeparam name="T"> Type of the underlying object. </typeparam> 
     public class FirebaseObject<T> 

--- a/src/Firebase/Http/HttpClientExtensions.cs
+++ b/src/Firebase/Http/HttpClientExtensions.cs
@@ -41,7 +41,7 @@ namespace Firebase.Database.Http
 
                 if (dictionary == null)
                 {
-                    return new FirebaseObject<T>[0];
+                    return Array.Empty<FirebaseObject<T>>();
                 }
 
                 return dictionary.Select(item => new FirebaseObject<T>(item.Key, item.Value)).ToList();

--- a/src/Firebase/Offline/DatabaseExtensions.cs
+++ b/src/Firebase/Offline/DatabaseExtensions.cs
@@ -13,6 +13,7 @@
         /// Create new instances of the <see cref="RealtimeDatabase{T}"/>.
         /// </summary>
         /// <typeparam name="T"> Type of elements. </typeparam>
+        /// <param name="query"> The child query. </param>
         /// <param name="filenameModifier"> Custom string which will get appended to the file name. </param>
         /// <param name="elementRoot"> Optional custom root element of received json items. </param>
         /// <param name="streamingOptions"> Realtime streaming options. </param> 
@@ -30,6 +31,7 @@
         /// </summary>
         /// <typeparam name="T"> Type of elements. </typeparam>
         /// <typeparam name="TSetHandler"> Type of the custom <see cref="ISetHandler{T}"/> to use. </typeparam>
+        /// <param name="query"> The child query. </param>
         /// <param name="filenameModifier"> Custom string which will get appended to the file name. </param>
         /// <param name="elementRoot"> Optional custom root element of received json items. </param>
         /// <param name="streamingOptions"> Realtime streaming options. </param> 
@@ -46,6 +48,7 @@
         /// <summary>
         /// Overwrites existing object with given key leaving any missing properties intact in firebase.
         /// </summary>
+        /// <param name="db"> Database instance. </param>
         /// <param name="key"> The key. </param>
         /// <param name="obj"> The object to set. </param>
         /// <param name="syncOnline"> Indicates whether the item should be synced online. </param>
@@ -59,6 +62,7 @@
         /// <summary>
         /// Overwrites existing object with given key.
         /// </summary>
+        /// <param name="db"> Database instance. </param>
         /// <param name="key"> The key. </param>
         /// <param name="obj"> The object to set. </param>
         /// <param name="syncOnline"> Indicates whether the item should be synced online. </param>
@@ -72,6 +76,7 @@
         /// <summary>
         /// Adds a new entity to the Database.
         /// </summary>
+        /// <param name="db"> Database instance. </param>
         /// <param name="obj"> The object to add.  </param>
         /// <param name="syncOnline"> Indicates whether the item should be synced online. </param>
         /// <param name="priority"> The priority. Objects with higher priority will be synced first. Higher number indicates higher priority. </param>
@@ -89,6 +94,7 @@
         /// <summary>
         /// Deletes the entity with the given key.
         /// </summary>
+        /// <param name="db"> Database instance. </param>
         /// <param name="key"> The key. </param>
         /// <param name="syncOnline"> Indicates whether the item should be synced online. </param>
         /// <param name="priority"> The priority. Objects with higher priority will be synced first. Higher number indicates higher priority. </param> 
@@ -140,7 +146,6 @@
         /// <param name="db"> Database instance. </param>
         /// <param name="key"> Key of the root element to modify. </param>
         /// <param name="propertyExpression"> Expression on the root element leading to target value to modify. </param>
-        /// <param name="value"> Value to put. </param>
         /// <param name="syncOnline"> Indicates whether the item should be synced online. </param>
         /// <param name="priority"> The priority. Objects with higher priority will be synced first. Higher number indicates higher priority. </param> 
         public static void Delete<T, TProperty>(this RealtimeDatabase<T> db, string key, Expression<Func<T, TProperty>> propertyExpression, bool syncOnline = true, int priority = 1)
@@ -177,7 +182,6 @@
         /// The key of the new entity is automatically generated.
         /// </summary>
         /// <typeparam name="T"> Type of the root elements. </typeparam>
-        /// <typeparam name="TSelector"> Type of the dictionary being modified</typeparam>
         /// <typeparam name="TProperty"> Type of the value within the dictionary being modified</typeparam>
         /// <param name="db"> Database instance. </param>
         /// <param name="key"> Key of the root element to modify. </param>

--- a/src/Firebase/Offline/OfflineEntry.cs
+++ b/src/Firebase/Offline/OfflineEntry.cs
@@ -16,8 +16,10 @@
         /// </summary>
         /// <param name="key"> The key. </param>
         /// <param name="obj"> The object. </param>
-        /// <param name="priority"> The priority. Objects with higher priority will be synced first. Higher number indicates higher priority. </param>  
+        /// <param name="data"> The json data. </param>
+        /// <param name="priority"> The priority. Objects with higher priority will be synced first. Higher number indicates higher priority. </param>
         /// <param name="syncOptions"> The sync options. </param>
+        /// <param name="isPartial"> A value indicating whether this is only a partial object. </param>
         public OfflineEntry(string key, object obj, string data, int priority, SyncOptions syncOptions, bool isPartial = false)
         {
             this.Key = key;
@@ -37,6 +39,7 @@
         /// <param name="obj"> The object. </param>
         /// <param name="priority"> The priority. Objects with higher priority will be synced first. Higher number indicates higher priority. </param>  
         /// <param name="syncOptions"> The sync options. </param>
+        /// <param name="isPartial"> A value indicating whether this is only a partial object. </param>
         public OfflineEntry(string key, object obj, int priority, SyncOptions syncOptions, bool isPartial = false)
             : this(key, obj, JsonConvert.SerializeObject(obj), priority, syncOptions, isPartial)
         {

--- a/src/Firebase/Offline/RealtimeDatabase.cs
+++ b/src/Firebase/Offline/RealtimeDatabase.cs
@@ -43,9 +43,10 @@
         /// <param name="elementRoot"> The element Root. </param>
         /// <param name="offlineDatabaseFactory"> The offline database factory.  </param>
         /// <param name="filenameModifier"> Custom string which will get appended to the file name.  </param>
-        /// <param name="streamChanges"> Specifies whether changes should be streamed from the server.  </param>
-        /// <param name="pullEverythingOnStart"> Specifies if everything should be pull from the online storage on start. It only makes sense when <see cref="streamChanges"/> is set to true. </param>
+        /// <param name="streamingOptions"> Specifies condition for which items get streamed. </param>
+        /// <param name="initialPullStrategy"> Specifies the strategy for initial pull of server data. </param>
         /// <param name="pushChanges"> Specifies whether changed items should actually be pushed to the server. If this is false, then Put / Post / Delete will not affect server data. </param>
+        /// <param name="setHandler"></param>
         public RealtimeDatabase(ChildQuery childQuery, string elementRoot, Func<Type, string, IDictionary<string, OfflineEntry>> offlineDatabaseFactory, string filenameModifier, StreamingOptions streamingOptions, InitialPullStrategy initialPullStrategy, bool pushChanges, ISetHandler<T> setHandler = null)
         {
             this.childQuery = childQuery;
@@ -93,7 +94,7 @@
         /// </summary>
         /// <param name="key"> The key. </param>
         /// <param name="obj"> The object to set. </param>
-        /// <param name="syncOnline"> Indicates whether the item should be synced online. </param>
+        /// <param name="syncOptions"> Specifies type of sync requested for given data. </param>
         /// <param name="priority"> The priority. Objects with higher priority will be synced first. Higher number indicates higher priority. </param>
         public void Set(string key, T obj, SyncOptions syncOptions, int priority = 1)
         {

--- a/src/Firebase/Offline/RealtimeDatabase.cs
+++ b/src/Firebase/Offline/RealtimeDatabase.cs
@@ -293,7 +293,7 @@
             }
             
             // there is an element root, which indicates the target location is not a collection but a single element
-            return Observable.Defer(async () => Observable.Return(await query.OnceSingleAsync<T>()).Select(e => new[] { new FirebaseObject<T>(this.elementRoot, e) }));
+            return Observable.Defer(async () => Observable.Return(await query.OnceSingleAsync<T>().ConfigureAwait(false)).Select(e => new[] { new FirebaseObject<T>(this.elementRoot, e) }));
         }
 
         private IDisposable InitializeStreamingSubscription(IObserver<FirebaseEvent<T>> observer)
@@ -336,11 +336,11 @@
                 try
                 {
                     var validEntries = this.Database.Where(e => e.Value != null);
-                    await this.PullEntriesAsync(validEntries.Where(kvp => kvp.Value.SyncOptions == SyncOptions.Pull));
+                    await PullEntriesAsync(validEntries.Where(kvp => kvp.Value.SyncOptions == SyncOptions.Pull)).ConfigureAwait(false);
 
                     if (this.pushChanges)
                     {
-                        await this.PushEntriesAsync(validEntries.Where(kvp => kvp.Value.SyncOptions == SyncOptions.Put || kvp.Value.SyncOptions == SyncOptions.Patch));
+                        await PushEntriesAsync(validEntries.Where(kvp => kvp.Value.SyncOptions == SyncOptions.Put || kvp.Value.SyncOptions == SyncOptions.Patch)).ConfigureAwait(false);
                     }
                 }
                 catch (Exception ex)
@@ -348,7 +348,7 @@
                     this.SyncExceptionThrown?.Invoke(this, new ExceptionEventArgs(ex));
                 }
 
-                await Task.Delay(this.childQuery.Client.Options.SyncPeriod);
+                await Task.Delay(childQuery.Client.Options.SyncPeriod).ConfigureAwait(false);
             }
         }
 
@@ -377,7 +377,7 @@
 
                 try
                 {
-                    await Task.WhenAll(tasks).WithAggregateException();
+                    await Task.WhenAll(tasks).WithAggregateException().ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -396,7 +396,7 @@
 
                 try
                 { 
-                    await Task.WhenAll(tasks).WithAggregateException();
+                    await Task.WhenAll(tasks).WithAggregateException().ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -407,13 +407,13 @@
 
         private async Task ResetAfterPull(Task<T> task, string key, OfflineEntry entry)
         {
-            await task;
+            await task.ConfigureAwait(false);
             this.SetAndRaise(key, new OfflineEntry(key, task.Result, entry.Priority, SyncOptions.None), FirebaseEventSource.OnlinePull);
         }
 
         private async Task ResetSyncAfterPush(Task task, string key, T obj)
         {
-            await this.ResetSyncAfterPush(task, key);
+            await ResetSyncAfterPush(task, key).ConfigureAwait(false);
 
             if (this.streamingOptions == StreamingOptions.None)
             {
@@ -423,7 +423,7 @@
 
         private async Task ResetSyncAfterPush(Task task, string key)
         {
-            await task;
+            await task.ConfigureAwait(false);
             this.ResetSyncOptions(key);
         }
 

--- a/src/Firebase/Offline/SetHandler.cs
+++ b/src/Firebase/Offline/SetHandler.cs
@@ -6,17 +6,18 @@
 
     public class SetHandler<T> : ISetHandler<T>
     {
-        public virtual async Task SetAsync(ChildQuery query, string key, OfflineEntry entry)
+        public virtual Task SetAsync(ChildQuery query, string key, OfflineEntry entry)
         {
             using (var child = query.Child(key))
             {
                 if (entry.SyncOptions == SyncOptions.Put)
                 {
-                    await child.PutAsync(entry.Data);
+                    return child.PutAsync(entry.Data);
                 }
                 else
                 {
-                    await child.PatchAsync(entry.Data);
+                    
+                    return child.PatchAsync(entry.Data);
                 }
             }
         }

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -172,11 +172,11 @@ namespace Firebase.Database.Query
         /// <param name="timeout"> Optional timeout value. </param>
         /// <typeparam name="T"> Type of <see cref="obj"/> </typeparam>
         /// <returns> The <see cref="Task"/>. </returns>
-        public async Task PatchAsync(string data, TimeSpan? timeout = null)
+        public Task PatchAsync(string data, TimeSpan? timeout = null)
         {
             var c = this.GetClient(timeout);
 
-            await this.Silent().SendAsync(c, data, new HttpMethod("PATCH")).ConfigureAwait(false);
+            return this.Silent().SendAsync(c, data, new HttpMethod("PATCH"));
         }
 
         /// <summary>
@@ -186,11 +186,11 @@ namespace Firebase.Database.Query
         /// <param name="timeout"> Optional timeout value. </param>
         /// <typeparam name="T"> Type of <see cref="obj"/> </typeparam>
         /// <returns> The <see cref="Task"/>. </returns>
-        public async Task PutAsync(string data, TimeSpan? timeout = null)
+        public Task PutAsync(string data, TimeSpan? timeout = null)
         {
             var c = this.GetClient(timeout);
 
-            await this.Silent().SendAsync(c, data, HttpMethod.Put).ConfigureAwait(false);
+            return this.Silent().SendAsync(c, data, HttpMethod.Put);
         }
 
         /// <summary>

--- a/src/Firebase/Query/FirebaseQuery.cs
+++ b/src/Firebase/Query/FirebaseQuery.cs
@@ -109,6 +109,7 @@ namespace Firebase.Database.Query
         /// Starts observing this query watching for changes real time sent by the server.
         /// </summary>
         /// <typeparam name="T"> Type of elements. </typeparam>
+        /// <param name="exceptionHandler"> Optional exception handler for the stream subscription. </param>
         /// <param name="elementRoot"> Optional custom root element of received json items. </param>
         /// <returns> Observable stream of <see cref="FirebaseEvent{T}"/>. </returns>
         public IObservable<FirebaseEvent<T>> AsObservable<T>(EventHandler<ContinueExceptionEventArgs<FirebaseException>> exceptionHandler = null, string elementRoot = "")
@@ -140,10 +141,9 @@ namespace Firebase.Database.Query
         /// <summary>
         /// Posts given object to repository.
         /// </summary>
-        /// <param name="obj"> The object. </param>
+        /// <param name="data"> The json data. </param>
         /// <param name="generateKeyOffline"> Specifies whether the key should be generated offline instead of online. </param>
         /// <param name="timeout"> Optional timeout value. </param>
-        /// <typeparam name="T"> Type of <see cref="obj"/> </typeparam>
         /// <returns> Resulting firebase object with populated key. </returns>
         public async Task<FirebaseObject<string>> PostAsync(string data, bool generateKeyOffline = true, TimeSpan? timeout = null)
         {
@@ -168,9 +168,8 @@ namespace Firebase.Database.Query
         /// <summary>
         /// Patches data at given location instead of overwriting them.
         /// </summary> 
-        /// <param name="obj"> The object. </param>
+        /// <param name="data"> The json data. </param>
         /// <param name="timeout"> Optional timeout value. </param>
-        /// <typeparam name="T"> Type of <see cref="obj"/> </typeparam>
         /// <returns> The <see cref="Task"/>. </returns>
         public Task PatchAsync(string data, TimeSpan? timeout = null)
         {
@@ -182,9 +181,8 @@ namespace Firebase.Database.Query
         /// <summary>
         /// Sets or overwrites data at given location.
         /// </summary> 
-        /// <param name="obj"> The object. </param>
+        /// <param name="data"> The json data. </param>
         /// <param name="timeout"> Optional timeout value. </param>
-        /// <typeparam name="T"> Type of <see cref="obj"/> </typeparam>
         /// <returns> The <see cref="Task"/>. </returns>
         public Task PutAsync(string data, TimeSpan? timeout = null)
         {

--- a/src/Firebase/Query/QueryExtensions.cs
+++ b/src/Firebase/Query/QueryExtensions.cs
@@ -54,7 +54,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Order data by given <see cref="propertyName"/>. Note that this is used mainly for following filtering queries and due to firebase implementation
+        /// Order data by given <paramref name="propertyName"/>. Note that this is used mainly for following filtering queries and due to firebase implementation
         /// the data may actually not be ordered.
         /// </summary>
         /// <param name="child"> The child. </param>
@@ -66,7 +66,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data greater or equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data greater or equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -77,7 +77,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data lower or equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data lower or equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -88,7 +88,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -99,7 +99,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data greater or equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data greater or equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -110,7 +110,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data lower or equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data lower or equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -121,7 +121,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -132,7 +132,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data greater or equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data greater or equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -143,7 +143,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data lower or equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data lower or equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -154,7 +154,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -165,7 +165,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data equal to the <see cref="value"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data equal to the <paramref name="value"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="value"> Value to start at. </param>
@@ -186,7 +186,7 @@ namespace Firebase.Database.Query
         }        
 
         /// <summary>
-        /// Limits the result to first <see cref="count"/> items.
+        /// Limits the result to first <paramref name="count"/> items.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="count"> Number of elements. </param>
@@ -197,7 +197,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Limits the result to last <see cref="count"/> items.
+        /// Limits the result to last <paramref name="count"/> items.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="count"> Number of elements. </param>
@@ -231,7 +231,7 @@ namespace Firebase.Database.Query
         /// <param name="query"> Current node. </param>
         /// <param name="item"> Object to fan out. </param>
         /// <param name="relativePaths"> Locations where to store the item. </param>
-        public static Task FanOut<T>(this ChildQuery child, T item, params string[] relativePaths)
+        public static Task FanOut<T>(this ChildQuery query, T item, params string[] relativePaths)
         {
             if (relativePaths == null)
             {
@@ -245,7 +245,7 @@ namespace Firebase.Database.Query
                 fanoutObject.Add(path, item);
             }
 
-            return child.PatchAsync(fanoutObject);
+            return query.PatchAsync(fanoutObject);
         }
     }
 }

--- a/src/Firebase/Query/QueryExtensions.cs
+++ b/src/Firebase/Query/QueryExtensions.cs
@@ -219,7 +219,7 @@ namespace Firebase.Database.Query
 
         public static async Task<FirebaseObject<T>> PostAsync<T>(this FirebaseQuery query, T obj, bool generateKeyOffline = true)
         {
-            var result = await query.PostAsync(JsonConvert.SerializeObject(obj, query.Client.Options.JsonSerializerSettings), generateKeyOffline);
+            var result = await query.PostAsync(JsonConvert.SerializeObject(obj, query.Client.Options.JsonSerializerSettings), generateKeyOffline).ConfigureAwait(false);
 
             return new FirebaseObject<T>(result.Key, obj);
         }
@@ -231,7 +231,7 @@ namespace Firebase.Database.Query
         /// <param name="query"> Current node. </param>
         /// <param name="item"> Object to fan out. </param>
         /// <param name="relativePaths"> Locations where to store the item. </param>
-        public static async Task FanOut<T>(this ChildQuery child, T item, params string[] relativePaths)
+        public static Task FanOut<T>(this ChildQuery child, T item, params string[] relativePaths)
         {
             if (relativePaths == null)
             {
@@ -245,7 +245,7 @@ namespace Firebase.Database.Query
                 fanoutObject.Add(path, item);
             }
 
-            await child.PatchAsync(fanoutObject);
+            return child.PatchAsync(fanoutObject);
         }
     }
 }

--- a/src/Firebase/Query/QueryFactoryExtensions.cs
+++ b/src/Firebase/Query/QueryFactoryExtensions.cs
@@ -30,7 +30,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Order data by given <see cref="propertyNameFactory"/>. Note that this is used mainly for following filtering queries and due to firebase implementation
+        /// Order data by given <paramref name="propertyNameFactory"/>. Note that this is used mainly for following filtering queries and due to firebase implementation
         /// the data may actually not be ordered.
         /// </summary>
         /// <param name="child"> The child. </param>
@@ -75,7 +75,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data greater or equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data greater or equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -86,7 +86,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data lower or equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data lower or equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -97,7 +97,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -108,7 +108,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data greater or equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data greater or equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -119,7 +119,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data lower or equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data lower or equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -130,7 +130,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -141,7 +141,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data greater or equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data greater or equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -152,7 +152,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data lower or equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data lower or equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -163,7 +163,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -174,7 +174,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Instructs firebase to send data equal to the <see cref="valueFactory"/>. This must be preceded by an OrderBy query.
+        /// Instructs firebase to send data equal to the <paramref name="valueFactory"/>. This must be preceded by an OrderBy query.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="valueFactory"> Value to start at. </param>
@@ -182,10 +182,10 @@ namespace Firebase.Database.Query
         public static FilterQuery EqualTo(this ParameterQuery child, Func<bool> valueFactory)
         {
             return new FilterQuery(child, () => "equalTo", valueFactory, child.Client);
-        }		
+        }
 
         /// <summary>
-        /// Limits the result to first <see cref="countFactory"/> items.
+        /// Limits the result to first <paramref name="countFactory"/> items.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="countFactory"> Number of elements. </param>
@@ -196,7 +196,7 @@ namespace Firebase.Database.Query
         }
 
         /// <summary>
-        /// Limits the result to last <see cref="countFactory"/> items.
+        /// Limits the result to last <paramref name="countFactory"/> items.
         /// </summary>
         /// <param name="child"> Current node. </param>
         /// <param name="countFactory"> Number of elements. </param>

--- a/src/Firebase/Streaming/FirebaseCache.cs
+++ b/src/Firebase/Streaming/FirebaseCache.cs
@@ -45,7 +45,8 @@ namespace Firebase.Database.Streaming
         /// The push data.
         /// </summary>
         /// <param name="path"> The path of incoming data, separated by slash. </param>  
-        /// <param name="data"> The data in json format as returned by firebase. </param>  
+        /// <param name="data"> The data in json format as returned by firebase. </param>
+        /// <param name="removeEmptyEntries"> A value indicating whether empty entries should be removed. </param>  
         /// <returns> Collection of top-level entities which were affected by the push. </returns>
         public IEnumerable<FirebaseObject<T>> PushData(string path, string data, bool removeEmptyEntries = true)
         {

--- a/src/Firebase/Streaming/FirebaseEvent.cs
+++ b/src/Firebase/Streaming/FirebaseEvent.cs
@@ -12,6 +12,7 @@ namespace Firebase.Database.Streaming
         /// <param name="key"> The key of the object. </param>
         /// <param name="obj"> The object. </param>
         /// <param name="eventType"> The event type. </param>
+        /// <param name="eventSource"> The origin of this event. </param>
         public FirebaseEvent(string key, T obj, FirebaseEventType eventType, FirebaseEventSource eventSource)
             : base(key, obj)
         {

--- a/src/Firebase/Streaming/FirebaseSubscription.cs
+++ b/src/Firebase/Streaming/FirebaseSubscription.cs
@@ -49,6 +49,7 @@ namespace Firebase.Database.Streaming
         /// </summary>
         /// <param name="observer"> The observer.  </param>
         /// <param name="query"> The query.  </param>
+        /// <param name="elementRoot"> Optional custom root element of received json items. </param>
         /// <param name="cache"> The cache. </param>
         public FirebaseSubscription(IObserver<FirebaseEvent<T>> observer, IFirebaseQuery query, string elementRoot, FirebaseCache<T> cache)
         {


### PR DESCRIPTION
Minor optimizations
- Add ConfigureAwait(false) to all await calls.
- Don't waste allocation of zero length array.
- Don't use async/await if not necessary (avoid state machine creation under the hood).

If you think my ConfigureAwait additions in RealtimeDatabase will cause concurrency issues, do you mind if I just change the OfflineDatabase backing dictionary to a concurrent dictionary? If not, I'll just revert those changes.

XML doc fixes
Installed an FX analyzers nuget package locally to expose a bunch of warnings, and fixed most of the ones related to xml documentation.