### PR TITLE
Validating end of stream to reconnect, and not up 100% CPU usage

### DIFF
--- a/src/Firebase/Streaming/FirebaseSubscription.cs
+++ b/src/Firebase/Streaming/FirebaseSubscription.cs
@@ -107,6 +107,9 @@ namespace Firebase.Database.Streaming
 
                             line = reader.ReadLine()?.Trim();
 
+                            if (((System.IO.StreamReader)reader).EndOfStream)
+                                throw new Exception("EndOfStream. Reconnecting..");
+
                             if (string.IsNullOrWhiteSpace(line))
                             {
                                 continue;


### PR DESCRIPTION
In a company project, it has this library, and every day we had to restart the service because the CPU reached 100%.
How in that issue:
https://github.com/step-up-labs/firebase-database-dotnet/issues/94

When analyzing the process, analyzing the "ReceiveThread" method, from the "FirebaseSubscription" class, was in an IO loop. When debugging the project for 1 day, I realized that the stream was coming to an end, and was in the loop. I added the validation to be thrown an exception, and it will be reconnected to the stream in the next loop. After that, it is 3 months with no CPU problems.