### PR TITLE
Fixed `LiteDB` security issue

### DIFF
--- a/src/Firebase/Firebase.csproj
+++ b/src/Firebase/Firebase.csproj
@@ -30,10 +30,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="4.1.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Reactive" Version="4.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
+    <PackageReference Include="LiteDB" Version="5.0.17" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Firebase/Offline/ConcurrentOfflineDatabase.cs
+++ b/src/Firebase/Offline/ConcurrentOfflineDatabase.cs
@@ -118,7 +118,9 @@
         public void Clear()
         {
             this.ccache.Clear();
-            this.db.Delete<OfflineEntry>(Query.All());
+            // Only works for v4, v5 see https://github.com/mbdavid/LiteDB/issues/1478
+            //this.db.Delete<OfflineEntry>(Query.All());
+            this.db.DeleteMany<OfflineEntry>(_ => true);
         }
 
         /// <summary>

--- a/src/Firebase/Offline/OfflineDatabase.cs
+++ b/src/Firebase/Offline/OfflineDatabase.cs
@@ -113,7 +113,9 @@
         public void Clear()
         {
             this.cache.Clear();
-            this.db.Delete<OfflineEntry>(Query.All());
+            // Only works for v4, v5 see https://github.com/mbdavid/LiteDB/issues/1478
+            //this.db.Delete<OfflineEntry>(Query.All());
+            this.db.DeleteMany<OfflineEntry>(_ => true);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR updates the `LiteDB` dependency to its latest version and fixes the security vulnerability. For this, following code needed to be replaced.

```cs
this.db.Delete<OfflineEntry>(Query.All());
```

with

```cs
// Only works for v4, v5 see https://github.com/mbdavid/LiteDB/issues/1478
this.db.DeleteMany<OfflineEntry>(_ => true);
```
Fixed https://github.com/step-up-labs/firebase-database-dotnet/issues/316
Security: [GHSA-3x49-g6rc-c284](https://github.com/mbdavid/LiteDB/security/advisories/GHSA-3x49-g6rc-c284)