### PR TITLE
Added support for namespace query string

### DIFF
--- a/src/Firebase/Firebase.csproj
+++ b/src/Firebase/Firebase.csproj
@@ -2,24 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>FirebaseDatabase.net</PackageId>
+    <PackageId>FirebaseDatabase.EmulatorSupported.net</PackageId>
     <PackageVersion>4.2.0</PackageVersion>
-    <Authors>Step Up Labs, Inc.</Authors>
-    <Description>Complex C# library for Firebase Realtime Database built on top of Firebase REST API. Among others it supports following:
-
-      * Offline storage
-      * Querying using available filters
-      * Passing in authentication token
-      * Streaming online changes
-      * Directly Posting / Putting / Patching online data
-
-      Streaming changes (both online and offline) are done using Reactive Extensions.
-    </Description>
+    <Authors>Yewo Theu</Authors>
+    <Description>A fork of the Firebase.net package by StepUp Labs which supports the use of firebase emulator for locally hosted realtime database.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageIconUrl>https://github.com/step-up-labs/firebase-database-dotnet/raw/master/art/FirebaseLogo.128x128.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/step-up-labs/firebase-database-dotnet</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Yewo-Devs/firebase-database-dotnet-emulator-supported</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/step-up-labs/firebase-database-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <Copyright>Step Up Labs, Inc. 2019</Copyright>
+    <Copyright>Yewo Theu, 2024.</Copyright>
     <PackageTags>Firebase Database Realtime</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Firebase/FirebaseClient.cs
+++ b/src/Firebase/FirebaseClient.cs
@@ -18,20 +18,23 @@ namespace Firebase.Database
     {
         internal readonly IHttpClientProxy HttpClient;
         internal readonly FirebaseOptions Options;
+		private readonly string baseUrl;
 
-        private readonly string baseUrl;
+		public readonly string ns;
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FirebaseClient"/> class.
         /// </summary>
         /// <param name="baseUrl"> The base url. </param>
         /// <param name="options"> The Firebase options. </param>  
-        public FirebaseClient(string baseUrl, FirebaseOptions options = null)
+        public FirebaseClient(string baseUrl, FirebaseOptions options = null, string ns = null)
         {
             this.Options = options ?? new FirebaseOptions();
-            this.HttpClient = Options.HttpClientFactory.GetHttpClient(null);
+			this.HttpClient = Options.HttpClientFactory.GetHttpClient(null);
 
             this.baseUrl = baseUrl;
+			this.ns = ns;
 
             if (!this.baseUrl.EndsWith("/"))
             {

--- a/src/Firebase/Query/ChildQuery.cs
+++ b/src/Firebase/Query/ChildQuery.cs
@@ -47,7 +47,12 @@ namespace Firebase.Database.Query
 
             if (!(child is ChildQuery))
             {
-                return s + ".json";
+				if (!string.IsNullOrEmpty(child.Client.ns))
+				{
+					return s + ".json" + $"?ns={child.Client.ns}";
+				}
+
+				return s + ".json";
             }
 
             return s;


### PR DESCRIPTION
I was experimenting with a locally hosted instance of firebase emulator which allows you to access firebase services on your local machine for development and testing purposes. I noticed the package does not append the namespace query param to the end of the request uri so I added that functionality with very minimal change to the package.